### PR TITLE
Fix invalid reference to ty

### DIFF
--- a/src/assert-type.coffee
+++ b/src/assert-type.coffee
@@ -201,7 +201,7 @@ compositeTypes =
 
   # instance of given constructor (ditto)
   'inst.of': (Cons) ->
-                T(ty.fun)(Cons)
+                T(s.fun)(Cons)
                 # TODO: improve name & description
                 makeType "inst.of(...)", "instance of a specific constructor", (x) ->
                   s.obj(x) and (x instanceof Cons)


### PR DESCRIPTION
Thanks for the wonderful module does exactly what I was looking for. Seems like there's a small bug in ty.inst.of function referencing ty.fun instead of s.fun.
